### PR TITLE
Add admin users

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -42,7 +42,8 @@ module.exports = {
 				lastname: "Kowalski",
 				email: "jkowalski@example.com",
 				password: "ff174f1711656f0f640a0e66442dc58c6efb00d5",
-				liked: [0, 1, 2]
+				liked: [0, 1, 2],
+				admin: false
 			}
 		],
 		posts: [
@@ -77,7 +78,8 @@ module.exports = {
 					lastname: decode(row.lastname),
 					email: decode(row.email),
 					password: row.password,
-					liked: row.liked.split(",").filter(v => v.length > 0).map(v => parseInt(v) ?? -1)
+					liked: row.liked.split(",").filter(v => v.length > 0).map(v => parseInt(v) ?? -1),
+					admin: row.admin
 				});
 				// FIXME: Find a better way to clone an object
 				original_state.users = JSON.parse(JSON.stringify(module.exports.db.users));
@@ -127,7 +129,7 @@ module.exports = {
 			const user = module.exports.db.users[ui];
 			const old_index = original_state.users?.findIndex(v => v.id == user.id) ?? -1;
 			if (old_index < 0) {
-				changes.push(`INSERT INTO users (id, firstname, lastname, email, password, liked) VALUES (DEFAULT, '${encode(user.firstname)}', '${encode(user.lastname)}', '${encode(user.email)}', '${user.password}', '${user.liked.join(",")}')`);
+				changes.push(`INSERT INTO users (id, firstname, lastname, email, password, liked, admin) VALUES (DEFAULT, '${encode(user.firstname)}', '${encode(user.lastname)}', '${encode(user.email)}', '${user.password}', '${user.liked.join(",")}', ${user.admin})`);
 				original_state.users.push({ id: user.id, firstname: user.firstname, lastname: user.lastname, email: user.email, password: user.password, liked: user.liked });
 				continue;
 			}
@@ -153,6 +155,10 @@ module.exports = {
 			if (liked_old_rep != liked_rep) {
 				changes.push(`UPDATE users SET liked='${liked_rep}' WHERE id=${user.id}`);
 				original_state.users[old_index].liked = JSON.parse(JSON.stringify(user.liked));
+			}
+			if (old_version.admin != user.admin) {
+				changes.push(`UPDATE users SET admin=${user.admin} WHERE id=${user.id}`);
+				original_state.users[old_index].admin = user.admin;
 			}
 		}
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ app.get("/post_added", require("./pages/post_added"));
 app.get("/create_post", require("./pages/create_post"));
 app.get("/signup", require("./pages/signup"));
 app.get("/post/:id", require("./pages/post"));
+app.get("/admin", require("./pages/admin"));
 
 app.use("/api/", require("./api/"));
 

--- a/src/pages/admin.js
+++ b/src/pages/admin.js
@@ -1,0 +1,13 @@
+const sessions = require("../sessions");
+module.exports = (req, res) => {
+	if(!sessions.logged_in(req)){
+		res.redirect("/login");
+		return;
+	}
+	const user = sessions.user_from_session(req.cookies.session);
+	if(!user.admin) {
+		res.redirect("/?msg=no_perms");
+		return;
+	}
+	res.render("pages/admin");
+};

--- a/web/pages/admin.ejs
+++ b/web/pages/admin.ejs
@@ -1,0 +1,52 @@
+<%- include("../partials/header") %>
+<script src="https://cdn.tiny.cloud/1/fr6kjy3uthc0coft8ony3vo5wdtv9k5xqufxb35pts3gsh2y/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+<script>
+	tinymce.init({
+		selector: "textarea#post_content_ta",
+		plugins: "anchor autolink charmap codesample emoticons image link lists media searchreplace table visualblocks wordcount checklist mediaembed casechange export formatpainter pageembed linkchecker a11ychecker tinymcespellchecker permanentpen powerpaste advtable advcode editimage tableofcontents footnotes autocorrect",
+		toolbar: "undo redo bold italic underline strikethrough | link image media table | spellcheckdialog a11ycheck | align lineheight | checklist numlist bullist indent outdent | emoticons charmap | removeformat",
+	});
+</script>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
+
+<title>Panel Administratora</title>
+<div class="container">
+	<div class="pb-2 mb-2 border-bottom">
+		<h2>Panel Administratora</h2>
+	</div>
+	
+	<div class="pb-2 mb-2">
+		<h3>Dodaj miasto</h3>
+	</div>
+
+	<div class="pb-2 mb-2">
+		<p>
+			<!-- TODO: Put actual controls here -->
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pretium tellus et eros laoreet, et ultrices arcu cursus. Duis vulputate id dolor eu hendrerit. Nunc ultrices interdum neque, suscipit malesuada mi tincidunt in. Proin et nunc blandit, tristique orci nec, commodo arcu. Fusce a dolor nec elit dignissim convallis at non est. Nunc eu venenatis mauris. Donec tristique vitae lorem et dictum. Phasellus eget accumsan turpis, non viverra nisl. Nullam convallis pretium pulvinar. Proin orci erat, rhoncus vel ultrices ut, sodales id eros. Sed accumsan feugiat tincidunt. Phasellus tristique iaculis elit id laoreet.
+		</p>
+	</div>
+	
+	<div class="pb-2 mb-2">
+		<h3>Nagłówek</h3>
+	</div>
+
+	<div class="pb-2 mb-2">
+		<p>
+			<!-- TODO: Put actual controls here -->
+			In lacinia dictum est et ornare. Etiam vel tortor quis elit posuere placerat id vel turpis. Nam iaculis ornare vestibulum. Quisque eleifend facilisis arcu, commodo vulputate leo condimentum tristique. In egestas facilisis egestas. Sed facilisis blandit justo, nec placerat mi placerat a. Suspendisse potenti. Duis pharetra elit quis ex aliquam, sit amet volutpat mauris suscipit. Ut facilisis vitae eros eget efficitur. Phasellus a nisl lectus. Nullam at justo et magna gravida pretium quis vitae nulla. Nullam auctor urna risus, quis commodo quam posuere ut. Nunc tellus nulla, lobortis ut nisi vel, ultrices tempor erat.
+		</p>
+	</div>
+	
+	<div class="pb-2 mb-2">
+		<h3>Nagłówek</h3>
+	</div>
+
+	<div class="pb-2 mb-2">
+		<p>
+			<!-- TODO: Put actual controls here -->
+			Cras id varius neque, vel ultricies ex. Etiam ac nisl ac purus porta molestie ultricies at nunc. Morbi sit amet posuere risus, sit amet sodales eros. Proin ex orci, facilisis sit amet semper sed, gravida in nisl. Maecenas in nunc justo. Sed porttitor, purus at ultricies volutpat, risus mi molestie eros, at porttitor nisi nulla non justo. Sed semper sodales magna, vitae auctor mauris hendrerit vel. Duis mattis aliquet sapien. Vivamus felis sem, viverra et nulla suscipit, congue bibendum felis. Phasellus molestie metus velit, pharetra dignissim nisi eleifend at. Donec at feugiat dolor, et ullamcorper nibh. Fusce dignissim urna quis gravida lacinia.
+		</p>
+	</div>
+
+</div>
+<%- include("../partials/footer") %>

--- a/web/partials/nav.ejs
+++ b/web/partials/nav.ejs
@@ -11,6 +11,9 @@
 			<div class="navbar-nav">
 				<% if (locals.logged_in) { %>
 					<a class="nav-link" href="/create_post">Zgłoś pomysł</a>
+					<% if (locals.user.admin) { %>
+						<a href="/admin" class="nav-link">Panel Administratora</a>
+					<% } %>
 					<a class="nav-link" href="/api/logout">Wyloguj się</a>
 				<% } else { %>
 					<a class="nav-link" href="/login">Zaloguj się</a>


### PR DESCRIPTION
This patch adds an `admin` flag to each users
When this flag is set and said user is logged in a new button appears
on the navigation bar. The button redirects the user to the `/admin`
endpoint, where they will be able to do management tasks.

For now the admin panel is just a simple lorem ipsum with a few headers
but in the future it will have more features such as content moderation,
city creation and approval as well as user management.